### PR TITLE
Added Origin Signature for TxHash

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "files.associations": {
+        "archethic.h": "c",
+        "os.h": "c",
+        "format.h": "c",
+        "menu.h": "c"
+    }
+}

--- a/run.sh
+++ b/run.sh
@@ -4,3 +4,6 @@ make
 # ../speculos/speculos.py --seed hex:9A34A233C48B77D48856ED171792D0B167F50D9A8148769E000D1F3C75F74C15 bin/app.elf
 ../speculos/speculos.py --seed hex:6fa774718b0f086101e7a0bf43f81944f2eea0392bc3452ac314cc444f19978989c62be4110f8fd3e543875e9f3fe2e2240f554cf16cfebf673b112ac44ec016 --color JADE_GREEN bin/app.elf
 # ../speculos/speculos.py bin/app.elf
+
+# Debug Mode
+# ../speculos/speculos.py --seed hex:6fa774718b0f086101e7a0bf43f81944f2eea0392bc3452ac314cc444f19978989c62be4110f8fd3e543875e9f3fe2e2240f554cf16cfebf673b112ac44ec016 -d bin/app.elf & ../speculos/tools/debug.sh bin/app.elf

--- a/src/archethic.c
+++ b/src/archethic.c
@@ -163,7 +163,7 @@ void generateKeyFromWallet(uint32_t address_index_offset, uint8_t *encoded_walle
 
     // Parse the Derivation Path into components here
     int path_len = encoded_wallet[seek_bytes];
-   
+
     char temp_der_path[30];
     explicit_bzero(temp_der_path, sizeof(temp_der_path));
 
@@ -220,15 +220,12 @@ void generateKeyFromWallet(uint32_t address_index_offset, uint8_t *encoded_walle
         }
     }
 
-    // PRINTF("\n Coin Type %d \n", coin_type);
-    // PRINTF("\n Account %d \n", account);
-    // PRINTF("\n Addr Index %d \n", address_index);
-
     // Offset the index if any
     address_index += address_index_offset;
 
     cx_curve_t curve;
     *curve_type = encoded_wallet[seek_bytes + 1 + path_len];
+
     switch (*curve_type)
     {
     case 0:

--- a/src/archethic.h
+++ b/src/archethic.h
@@ -29,6 +29,8 @@ typedef void (*action_validate_cb)(bool);
 
 #define MAX_ENCODE_WALLET_LEN 200
 
+
+
 typedef struct
 {
     uint8_t encodedWallet[MAX_ENCODE_WALLET_LEN];
@@ -55,6 +57,7 @@ typedef struct
     uint8_t service_index;
     uint32_t seek_bytes;
 } tx_struct_t;
+
 
 void io_exchange_with_code(uint16_t code, uint16_t tx);
 

--- a/src/main.c
+++ b/src/main.c
@@ -15,6 +15,7 @@ bolos_ux_params_t G_ux_params;
 #define INS_GET_VERSION 0x01
 #define INS_GET_PUBLIC_KEY 0x02
 #define INS_GET_ADDRESS 0x04
+#define INS_SIGN_HASH_ORIGIN 0x06
 #define INS_SIGN_HASH 0x08
 
 typedef void handler_fn_t(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dataLength, volatile unsigned int *flags);
@@ -23,6 +24,7 @@ handler_fn_t handleGetVersion;
 handler_fn_t handleGetPublicKey;
 handler_fn_t handleGetAddress;
 handler_fn_t handleSignHash;
+handler_fn_t handleSignHashOrigin;
 
 static handler_fn_t *lookupHandler(uint8_t ins)
 {
@@ -36,6 +38,8 @@ static handler_fn_t *lookupHandler(uint8_t ins)
 		return handleGetAddress;
 	case INS_SIGN_HASH:
 		return handleSignHash;
+	case INS_SIGN_HASH_ORIGIN:
+		return handleSignHashOrigin;
 	default:
 		return NULL;
 	}

--- a/src/signHashOrigin.c
+++ b/src/signHashOrigin.c
@@ -1,0 +1,128 @@
+/*******************************************************************************
+ *   Archethic Ledger Bolos App
+ *   (c) 2022 Varun Deshpande, Uniris
+ *
+ *  Licensed under the GNU Affero General Public License, Version 3 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.en.html
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ********************************************************************************/
+#include <os.h>
+#include "archethic.h"
+#include "common/format.h"
+#include "ui/menu.h"
+
+
+static action_validate_cb g_validate_origin_sig;
+static char g_derivation_origin_path[30];
+static char g_txHash_origin[200];
+
+UX_STEP_NOCB(ux_flow_orig_sig_init, bnnn_paging, {
+                                                     .title = "Confirm Signing",
+                                                     .text = "Origin Signature",
+                                                 });
+
+UX_STEP_NOCB(ux_flow_orig_sig_derivation_path,
+             bnnn_paging,
+             {
+                 .title = "Derivation Path",
+                 .text = g_derivation_origin_path,
+             });
+
+UX_STEP_NOCB(ux_flow_orig_sig_txHash,
+             bnnn_paging,
+             {
+                 .title = "Txn Hash",
+                 .text = g_txHash_origin,
+             });
+
+UX_STEP_CB(ux_flow_approve_orig_sig,
+           pb,
+           (*g_validate_origin_sig)(true),
+           {
+               &C_icon_validate_14,
+               "Approve",
+           });
+
+UX_STEP_CB(ux_flow_reject_orig_sig,
+           pb,
+           (*g_validate_origin_sig)(false),
+           {
+               &C_icon_crossmark,
+               "Reject",
+           });
+
+UX_FLOW(ux_display_orig_sign_flow,
+        &ux_flow_orig_sig_init,
+        &ux_flow_orig_sig_derivation_path,
+        &ux_flow_orig_sig_txHash,
+        &ux_flow_approve_orig_sig,
+        &ux_flow_reject_orig_sig);
+
+void ui_action_validate_origin_signature(bool choice)
+{
+    if (choice)
+    {
+
+        cx_ecfp_private_key_t originPrivateKey;
+        cx_ecfp_public_key_t originPublicKey;
+
+        deriveArchEthicKeyPair(CX_CURVE_SECP256K1, 650, 0xffff, 0, NULL, 0, &originPrivateKey, &originPublicKey);
+
+        uint8_t asn_sign[200];
+        uint8_t asn_sign_len = 0;
+        unsigned int info = 0;
+
+        // Curve Type is SECP256K1
+        asn_sign[0] = 0x02;
+        // Origin is Ledger Device
+        asn_sign[1] = 0x04;
+
+        memcpy(asn_sign + 2, originPublicKey.W, originPublicKey.W_len);
+
+        uint8_t txHash[200];
+        
+        // CDATA starts at byte 5, 1st Byte is txHashLen
+        uint8_t txHashLen = G_io_apdu_buffer[5];
+        
+        // Next n bytes are txHash
+        memcpy(txHash, G_io_apdu_buffer + 5 + 1, txHashLen);
+        
+        asn_sign_len = cx_ecdsa_sign(&originPrivateKey, CX_RND_TRNG, CX_SHA256, txHash, txHashLen, asn_sign + originPublicKey.W_len + 2, 200 - originPublicKey.W_len - 2, &info);
+        asn_sign_len += originPublicKey.W_len + 2;
+
+        memcpy(G_io_apdu_buffer, asn_sign, asn_sign_len);
+
+        io_exchange_with_code(SW_OK, asn_sign_len);
+    }
+    else
+    {
+        io_exchange_with_code(SW_USER_REJECTED, 0);
+    }
+
+    ui_menu_main();
+}
+
+// data buffer is encoded as -> txnHashSize, txnHash
+void handleSignHashOrigin(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dataLength, volatile unsigned int *flags)
+{
+
+    *flags |= IO_ASYNCH_REPLY;
+
+    memset(g_derivation_origin_path, 0, sizeof(g_derivation_origin_path));
+    // g_derivation_path = "m/650'/ffff'/0'" always
+    strncpy(g_derivation_origin_path, "m/650'/ffff'/0'", 30);
+
+    snprintf(g_txHash_origin, sizeof(g_txHash_origin), "%.*H", dataBuffer[0], dataBuffer + 1);
+
+    g_validate_origin_sig = &ui_action_validate_origin_signature;
+
+    ux_flow_init(0, ux_display_orig_sign_flow, NULL);
+}

--- a/tests/archethic_client/archethic_cmd_builder.py
+++ b/tests/archethic_client/archethic_cmd_builder.py
@@ -32,6 +32,7 @@ class InsType(enum.IntEnum):
     INS_GET_VERSION = 0x01
     INS_GET_PUBLIC_KEY = 0x02
     INS_GET_ARCH_ADDR = 0x04
+    INS_SIGN_ORIG_TX = 0x06
     INS_SIGN_TX = 0x08
 
 
@@ -201,6 +202,30 @@ class ArchethicCommandBuilder:
 
         return self.serialize(cla=self.CLA,
                                 ins=InsType.INS_SIGN_TX,
+                                p1=0x01 if display else 0x00,
+                                p2=0x00,
+                                cdata=cdata)
+    
+    def sign_txn_hash_origin_build(self, txnHashLen, txnHash, display: bool = False):
+        """Command builder for SIGN_TX.
+
+        Parameters
+        ----------
+        txnHashLen: String<hex>
+            Length of the Hash Sent for signing
+        txnHash: String<hex>
+            Hash to be signed of length mentioned above
+
+        Returns
+        -------
+        bytes
+            APDU command for SIGN_TX.
+        """
+
+        cdata: bytes = bytes.fromhex(txnHashLen + txnHash)
+
+        return self.serialize(cla=self.CLA,
+                                ins=InsType.INS_SIGN_ORIG_TX,
                                 p1=0x01 if display else 0x00,
                                 p2=0x00,
                                 cdata=cdata)

--- a/tests/manual_testing/test.py
+++ b/tests/manual_testing/test.py
@@ -30,17 +30,24 @@ service_index = "00"
 receiver = "020019CA33A6CA9E69B5C29E6E8497CC5AC9675952F847347709AD39C92C1B1B5313"
 amount = "000000038407B700"
 
+# 1 byte
+hash_len = "20"
+txn_hash = "7829BE6ADB23E83AF08BE2F27977EE8FDA4E2FE6D40A514DAF1BE13A020F7CB2"
+
 # Address APDU
 # apdu_hex_payload = address_index + encrypted_key_plus_wallet
 # apdu_hex_payload = service_index + encrypted_key_plus_wallet
 
 # Sign APDU
 # apdu_hex_payload = address_index + receiver + amount + encrypted_key_plus_wallet
-apdu_hex_payload = service_index + receiver + amount + encrypted_key_plus_wallet
+# apdu_hex_payload = service_index + receiver + amount + encrypted_key_plus_wallet
+
+# Sign Hash Origin APDU
+apdu_hex_payload =  hash_len + txn_hash
 
 apdu_payload = bytes.fromhex(apdu_hex_payload)
 sw, response = transport.exchange(
-    cla=0xe0, ins=0x08, p1=0, p2=0, cdata=apdu_payload)
+    cla=0xe0, ins=0x06, p1=0, p2=0, cdata=apdu_payload)
 
 print(response.hex())
 transport.close()

--- a/tests/manual_testing/wallet_encoder_new.ex
+++ b/tests/manual_testing/wallet_encoder_new.ex
@@ -32,7 +32,7 @@ master_seed = :crypto.strong_rand_bytes(32)
 # {_ok, master_seed_length} =
 #   master_seed |> :erlang.byte_size() |> Integer.to_string() |> Base.encode16(case: :upper)
 
-{_ok, master_seed_length } = Base.decode16("20")
+{_ok, master_seed_length} = Base.decode16("20")
 
 {_ok, total_services} = Base.decode16("01")
 
@@ -54,7 +54,6 @@ service_name = "uco"
 derivation_path = "m/650'/0'/0'"
 
 # size_str = derivation_path |> String.length |> Integer.to_string(16)
-
 
 {_ok, wallet_curve} = Base.decode16("02")
 {_ok, hash_type} = Base.decode16("00")
@@ -82,7 +81,12 @@ IO.puts(Base.encode16(service_name))
 IO.puts("\n Derivation Path Length: ")
 IO.puts(Base.encode16(derivation_path_length))
 
-IO.puts("\n Derivation Path (" <> Base.encode16(derivation_path_length) <>":hex Bytes): [Coin type = 650, account = 0, index = 0]")
+IO.puts(
+  "\n Derivation Path (" <>
+    Base.encode16(derivation_path_length) <>
+    ":hex Bytes): [Coin type = 650, account = 0, index = 0]"
+)
+
 IO.puts(Base.encode16(derivation_path))
 
 IO.puts("\nWallet Curve (0:ed25519, 1:nistp256, 2:secp256k1): ")
@@ -196,6 +200,46 @@ IO.puts(
 IO.puts(Base.encode16(encoded_wallet_key))
 
 IO.puts("\n----------------------------------------------------")
+
+IO.puts("\n Encoding a Simple Transaction")
+
+# Transaction encoding
+# tx_version | senderAddr | tx_type | code_size | content_size
+# | ownership_length | total_uco_transfers | recieverAddr | amount | total_nft_transfers | recipients
+
+{_ok, tx_version} = Base.decode16("00000001")
+{_ok, tx_type} = Base.decode16("FD")
+{_ok, code_size} = Base.decode16("00000000")
+{_ok, content_size} = Base.decode16("00000000")
+{_ok, ownership_length} = Base.decode16("00")
+{_ok, total_uco_transfers} = Base.decode16("01")
+{_ok, total_nft_transfers} = Base.decode16("00")
+{_ok, recipients} = Base.decode16("00")
+
+# 151 UC0 in hex, 1 UCO = 10^8
+{_ok, amount} = Base.decode16("000000038407B700")
+
+{_ok, receiver_addr} = Base.decode16("020019CA33A6CA9E69B5C29E6E8497CC5AC9675952F847347709AD39C92C1B1B5313")
+{_ok, sender_addr} = Base.decode16("02008C9C7EE489E47E3867CD8CDADDA4867C6A874880E25CF68346D05B5C985CA1ED")
+
+encoded_txn = tx_version <> sender_addr <> tx_type <> code_size <> content_size <> ownership_length <> total_uco_transfers <> receiver_addr <> amount <> total_nft_transfers <> recipients
+
+IO.puts("Encoded Transaction:")
+IO.puts(Base.encode16(encoded_txn))
+
+#  Should be Equal to this
+# "0000000102008C9C7EE489E47E3867CD8CDADDA4867C6A874880E25CF68346D05B5C985CA1EDFD00000000000000000001020019CA33A6CA9E69B5C29E6E8497CC5AC9675952F847347709AD39C92C1B1B5313000000038407B7000000"
+
+txn_hash = :crypto.hash(:sha256, encoded_txn)
+
+IO.puts("Transaction Hash: ---")
+IO.puts(Base.encode16(txn_hash))
+
+# From Script
+# 7829BE6ADB23E83AF08BE2F27977EE8FDA4E2FE6D40A514DAF1BE13A020F7CB2
+# From Device
+# 7829BE6ADB23E83AF08BE2F27977EE8FDA4E2FE6D40A514DAF1BE13A020F7CB2
+
 
 """
 {_ok, address_header} = Base.decode16("E0040000")

--- a/tests/test_sign_origin.py
+++ b/tests/test_sign_origin.py
@@ -1,0 +1,22 @@
+import ecdsa
+from hashlib import sha256
+
+from ecdsa.curves import SECP256k1
+from ecdsa.keys import VerifyingKey
+from ecdsa.util import sigdecode_der
+
+from utils import verify_signature, pubkey_pair, str_to_hex_int, sign_pair
+
+
+def test_sign_txn_hash_origin(cmd, hid):
+    hash_len = "20"
+    txn_hash = "7829BE6ADB23E83AF08BE2F27977EE8FDA4E2FE6D40A514DAF1BE13A020F7CB2"
+
+    curve_type, origin_type, pubkey_tag, public_key, sign_tag, sign_len, asn_der_sign = cmd.sign_txn_hash_origin(
+        hid, hash_len, txn_hash, hid)
+
+    pubkeyPair = pubkey_pair(public_key)
+    sign = sign_pair(asn_der_sign)
+
+    assert(verify_signature(pubkeyPair, str_to_hex_int(txn_hash), sign) == True)
+    assert(curve_type == "02")


### PR DESCRIPTION
This Closes #36 

This Makes use of Origin Private Key to sign the transaction. 

APDU Command for Origin Txn Sign
"e0`06`000021`20` `7829be6adb23e83af08be2f27977ee8fda4e2fe6d40a514daf1be13a020f7cb2`"
06 is the descriptor for function `handleSignHashOrigin` to run.
20 is the size of hash in Hex (32 Bytes in Int)
Next n (here 32) bytes are transaction hash which need to be signed.

Uses Default Origin Derivation path to sign the transaction
m/650'/ffff'/0'

Tested on Speculos
Tested on Ledger Nano S